### PR TITLE
remove the too large server side decorations box shadow as it blocks the window behind it + issues with resizing

### DIFF
--- a/McOS-MJV-Dark-mode/gtk-3.0/gtk-dark.css
+++ b/McOS-MJV-Dark-mode/gtk-3.0/gtk-dark.css
@@ -10928,11 +10928,13 @@ popup decoration {
 
 .ssd decoration {
   margin: 0px;
-  box-shadow: 1px 8px 8px 8px rgba(0, 0, 0, 0.16),0 0 0 1px rgba(0, 0, 0, 0.18);}
+  box-shadow: none;
+}
 
 .ssd decoration:backdrop {
   margin: 0px;
-  box-shadow: 1px 8px 8px 8px rgba(0, 0, 0, 0.16),0 0 0 1px rgba(0, 0, 0, 0.18);}
+  box-shadow: none;
+}
 
 .csd.popup decoration {
   border-radius: 5px;

--- a/McOS-MJV-Dark-mode/gtk-3.0/gtk.css
+++ b/McOS-MJV-Dark-mode/gtk-3.0/gtk.css
@@ -10928,11 +10928,13 @@ popup decoration {
 
 .ssd decoration {
   margin: 0px;
-  box-shadow: 1px 8px 8px 8px rgba(0, 0, 0, 0.16),0 0 0 1px rgba(0, 0, 0, 0.18);}
+  box-shadow: none;
+}
 
 .ssd decoration:backdrop {
   margin: 0px;
-  box-shadow: 1px 8px 8px 8px rgba(0, 0, 0, 0.16),0 0 0 1px rgba(0, 0, 0, 0.18);}
+  box-shadow: none;
+}
 
 .csd.popup decoration {
   border-radius: 5px;

--- a/McOS-MJV/gtk-3.0/gtk-dark.css
+++ b/McOS-MJV/gtk-3.0/gtk-dark.css
@@ -10928,11 +10928,13 @@ popup decoration {
 
 .ssd decoration {
   margin: 0px;
-  box-shadow: 1px 8px 8px 8px rgba(0, 0, 0, 0.16),0 0 0 1px rgba(0, 0, 0, 0.18);}
+  box-shadow: none;
+}
 
 .ssd decoration:backdrop {
   margin: 0px;
-  box-shadow: 1px 8px 8px 8px rgba(0, 0, 0, 0.16),0 0 0 1px rgba(0, 0, 0, 0.18);}
+  box-shadow: none;
+}
 
 .csd.popup decoration {
   border-radius: 5px;

--- a/McOS-MJV/gtk-3.0/gtk.css
+++ b/McOS-MJV/gtk-3.0/gtk.css
@@ -10656,7 +10656,8 @@ popup decoration {
 
 .ssd decoration {
   margin: 0px;
-  box-shadow: 1px 8px 8px 8px rgba(0, 0, 0, 0.16),0 0 0 1px rgba(0, 0, 0, 0.18);}
+  box-shadow: none;
+}
 
 .ssd decoration:backdrop {
   margin: 0px;

--- a/McOS-MJV/gtk-3.0/gtk.css
+++ b/McOS-MJV/gtk-3.0/gtk.css
@@ -10660,7 +10660,8 @@ popup decoration {
 
 .ssd decoration:backdrop {
   margin: 0px;
-  box-shadow: 1px 8px 8px 8px rgba(0, 0, 0, 0.16),0 0 0 1px rgba(0, 0, 0, 0.18);}
+  box-shadow: none;
+}
 
 .csd.popup decoration {
   border-radius: 4px;


### PR DESCRIPTION
Love the theme, thank you for making it.

I am using the theme on Ubuntu 18.04 (on a HiDPI laptop monitor) and I ran into a fairly small but pretty unpleasant problem. Specifically it looked like that the LARGE, mostly invisible shadow around the window was preventing me clicking on the window behind it very consistently as well as resizing grip seem to be far away from the border. This does not happen to all the windows, for example Gnome Tweak and gThumb are ok Meld, Firefox, Sublime, LibreOffer have this issue (maybe a GTK2 issue?)

On larger monitor this migh not be a problem but on HiDPI laptop screen the amount of space used by the shadow actually managed to impede my productivity when it came to switching windows. Please see screenshot below (the area between the visible border and the grip can not be click to unfocus the window)

![drag grip so far away](https://user-images.githubusercontent.com/582074/42669619-3ef6ec30-860b-11e8-99db-f1190d540260.png)

After some research inf Client Side Decorations (CSD) and Server Side Decorations (SSD) I figured was the issue was that `.ssd decorator` creates that large shadow but it is is still part of the window. Apparently SSDs are no longer the recommended part to create shadows (at least on gnome) and the WM supposed to create it itself. I verified this by looking over Gnome official Adwaita theme (https://mail.gnome.org/archives/commits-list/2016-February/msg06775.html) and the popular ARC theme both of which seem to not use a ssd box-shadow (or use 1px border on the bottom). 

I am offering this patch in the hopes that it will make it and this theme will work better in Gnome shell. I am open to discussing alternatives if you have them, though my theming knowledge it not extensive.

If the patch does work I'll be happy to create PRs for other themes.